### PR TITLE
fix port mappings so that the com.goticks.BackendRemoteDeployMain and…

### DIFF
--- a/chapter-remoting/src/main/resources/frontend-remote-deploy.conf
+++ b/chapter-remoting/src/main/resources/frontend-remote-deploy.conf
@@ -8,11 +8,11 @@ akka {
 
     deployment {
       /restInterface/boxOffice {
-        remote = "akka.tcp://backend@0.0.0.0:2552"
+        remote = "akka.tcp://backend@0.0.0.0:2551"
       }
 
       /restInterface/forwarder/boxOffice {
-        remote = "akka.tcp://backend@0.0.0.0:2552"
+        remote = "akka.tcp://backend@0.0.0.0:2551"
       }
 
     }
@@ -22,7 +22,7 @@ akka {
     enabled-transports = ["akka.remote.netty.tcp"]
     netty.tcp {
       hostname = "0.0.0.0"
-      port = 2551
+      port = 2552
     }
   }
 }


### PR DESCRIPTION
Fixed port mappings so that the com.gotickBackendRemoteDeployMain and com.goticks.FrontendRemoteDeployMain or com.goticks.FrontendRemoteDeployWatchMain can be launched at the same time.  The tests in multi-jvm:test still fail unfortunately.