### PR TITLE
Minor changes for removal of deprecation warning during compile.

### DIFF
--- a/chapter-testdriven/build.sbt
+++ b/chapter-testdriven/build.sbt
@@ -7,7 +7,7 @@ organization := "com.manning"
 scalaVersion := "2.11.7"
 
 libraryDependencies ++= {
-  val akkaVersion       = "2.4.2-RC2"
+  val akkaVersion       = "2.4.2"
   Seq(
     "com.typesafe.akka"       %%  "akka-actor"   % akkaVersion,
     "com.typesafe.akka"       %%  "akka-slf4j"   % akkaVersion,

--- a/chapter-testdriven/scala.sbt
+++ b/chapter-testdriven/scala.sbt
@@ -1,0 +1,6 @@
+scalaVersion := "2.11.7"
+
+scalacOptions ++= Seq(
+  "-target:jvm-1.7",
+  "-deprecation"
+)

--- a/chapter-testdriven/scala.sbt
+++ b/chapter-testdriven/scala.sbt
@@ -1,6 +1,6 @@
 scalaVersion := "2.11.7"
 
 scalacOptions ++= Seq(
-  "-target:jvm-1.7",
+  "-target:jvm-1.8",
   "-deprecation"
 )

--- a/chapter-testdriven/src/test/scala/aia/testdriven/StopSystemAfterAll.scala
+++ b/chapter-testdriven/src/test/scala/aia/testdriven/StopSystemAfterAll.scala
@@ -8,7 +8,7 @@ trait StopSystemAfterAll extends BeforeAndAfterAll {
   this: TestKit with Suite => //<co id="ch02-stop-system-self-type"/>
   override protected def afterAll() {
     super.afterAll()
-    system.shutdown() //<co id="ch02-stop-system-shutdown"/>
+    system.terminate() //<co id="ch02-stop-system-shutdown"/>
   }
 }
 //<end id="ch02-stopsystem"/>

--- a/chapter-testdriven/src/test/scala/aia/testdriven/StopSystemAfterAll.scala
+++ b/chapter-testdriven/src/test/scala/aia/testdriven/StopSystemAfterAll.scala
@@ -8,7 +8,7 @@ trait StopSystemAfterAll extends BeforeAndAfterAll {
   this: TestKit with Suite => //<co id="ch02-stop-system-self-type"/>
   override protected def afterAll() {
     super.afterAll()
-    system.terminate() //<co id="ch02-stop-system-shutdown"/>
+    system.terminate() //<co id="ch02-stop-system-terminate"/>
   }
 }
 //<end id="ch02-stopsystem"/>


### PR DESCRIPTION
I have;
* Added scala.sbt, to add scala compiler flags for targetting JVM 1.8 and for showing deprecation warnings
* Updated the version of Akka to 2.4.2 (from 2.4.2-RC2)
* Updated a test to use system.terminate() instead of, the now deprecated, system.shutdown().