### PR TITLE
Update for Akka 2.4.4 API and Scala 2.11.7

### DIFF
--- a/chapter-persistence/build.sbt
+++ b/chapter-persistence/build.sbt
@@ -4,7 +4,7 @@ version := "1.0"
 
 organization := "com.manning"
 
-scalaVersion := "2.11.6"
+scalaVersion := "2.11.7" // BUGBUG was 2.11.6
 
 scalacOptions ++= Seq(
   "-deprecation",
@@ -24,25 +24,35 @@ parallelExecution in Test := false
 fork := true
 
 libraryDependencies ++= {
-  val akkaVersion  = "2.3.12"
+  val akkaVersion  = "2.4.4"  // BUGBUG was 2.3.12
   val sprayVersion = "1.3.3"
   Seq(
     "com.typesafe.akka"         %%  "akka-actor"                     % akkaVersion,
-    "com.typesafe.akka"         %%  "akka-slf4j"                     % akkaVersion,
-    "com.typesafe.akka"         %%  "akka-persistence-experimental"  % akkaVersion,
+
+    "com.typesafe.akka"         %%  "akka-persistence"               % akkaVersion,
     "com.typesafe.akka"         %%  "akka-cluster"                   % akkaVersion,
-    "com.typesafe.akka"         %%  "akka-contrib"                   % akkaVersion,
+    "com.typesafe.akka"         %%  "akka-cluster-tools"             % akkaVersion,
+    "com.typesafe.akka"         %%  "akka-cluster-sharding"          % akkaVersion,
+    "org.iq80.leveldb"           %  "leveldb"                        % "0.7",
+    "org.fusesource.leveldbjni"  %  "leveldbjni-all"                 % "1.8",
+
+
     "com.typesafe.akka"         %%  "akka-testkit"                   % akkaVersion   % "test",
     "com.typesafe.akka"         %%  "akka-multi-node-testkit"        % akkaVersion   % "test",
+
     "io.spray"                  %%  "spray-can"                      % sprayVersion,
     "io.spray"                  %%  "spray-client"                   % sprayVersion,
     "io.spray"                  %%  "spray-json"                     % "1.3.2",
     "io.spray"                  %%  "spray-routing"                  % sprayVersion,
-    "commons-io"                %   "commons-io"                     % "2.4",
-    "org.scalatest"             %%  "scalatest"                      % "2.2.4"       % "test",
-    "ch.qos.logback"            %   "logback-classic"                % "1.1.2",
     "io.spray"                  %%  "spray-can"                      % sprayVersion,
-    "io.spray"                  %%  "spray-routing"                  % sprayVersion
+    "io.spray"                  %%  "spray-routing"                  % sprayVersion,
+
+    "commons-io"                %   "commons-io"                     % "2.4",
+
+    "org.scalatest"             %%  "scalatest"                      % "2.2.4"       % "test",
+
+    "com.typesafe.akka"         %%  "akka-slf4j"                     % akkaVersion,
+    "ch.qos.logback"            %   "logback-classic"                % "1.1.2"
   )
 }
 

--- a/chapter-persistence/build.sbt
+++ b/chapter-persistence/build.sbt
@@ -4,7 +4,7 @@ version := "1.0"
 
 organization := "com.manning"
 
-scalaVersion := "2.11.7" // BUGBUG was 2.11.6
+scalaVersion := "2.11.7"
 
 scalacOptions ++= Seq(
   "-deprecation",
@@ -24,7 +24,7 @@ parallelExecution in Test := false
 fork := true
 
 libraryDependencies ++= {
-  val akkaVersion  = "2.4.4"  // BUGBUG was 2.3.12
+  val akkaVersion  = "2.4.4"
   val sprayVersion = "1.3.3"
   Seq(
     "com.typesafe.akka"         %%  "akka-actor"                     % akkaVersion,

--- a/chapter-persistence/src/main/resources/application.conf
+++ b/chapter-persistence/src/main/resources/application.conf
@@ -24,6 +24,19 @@ akka {
   cluster {
     seed-nodes = ["akka.tcp://shoppers@127.0.0.1:2552", "akka.tcp://shoppers@127.0.0.1:2553"]
   }
+
+  persistence {
+    journal {
+      plugin = akka.persistence.journal.leveldb
+      leveldb {
+        dir = "target/persistence/journal"
+      }
+    }
+    snapshot-store {
+      plugin = "akka.persistence.snapshot-store.local"
+      local.dir = "target/persistence/snapshots"
+    }
+  }
 }
 
 //<start id="serialization_config"/>

--- a/chapter-persistence/src/main/scala/aia/persistence/Serializers.scala
+++ b/chapter-persistence/src/main/scala/aia/persistence/Serializers.scala
@@ -43,7 +43,7 @@ class BasketSnapshotSerializer extends Serializer {
   }
 
   def fromBinary(bytes: Array[Byte],
-                 clazz: Option[Class[_]]): AnyRef = {
+                 manifest: Option[Class[_]]): AnyRef = {
     val jsonStr = new String(bytes)
     jsonStr.parseJson.convertTo[Basket.Snapshot]
   }
@@ -61,7 +61,7 @@ object JsonFormats extends DefaultJsonProtocol {
 
   implicit val addedEventFormat: RootJsonFormat[Basket.Added] =
     jsonFormat1(Basket.Added)
-  implicit val reFormat: RootJsonFormat[Basket.ItemRemoved] =
+  implicit val removedEventFormat: RootJsonFormat[Basket.ItemRemoved] =
     jsonFormat1(Basket.ItemRemoved)
   implicit val updatedEventFormat: RootJsonFormat[Basket.ItemUpdated] =
     jsonFormat2(Basket.ItemUpdated)

--- a/chapter-persistence/src/main/scala/aia/persistence/rest/ShoppersServiceSupport.scala
+++ b/chapter-persistence/src/main/scala/aia/persistence/rest/ShoppersServiceSupport.scala
@@ -32,7 +32,7 @@ trait ShoppersServiceSupport {
         case Http.CommandFailed(cmd) =>
           println("Shopper service could not bind to " +
             s"$host:$port, ${cmd.failureMessage}")
-          system.shutdown()
+          system.terminate()
       }
   }
 }

--- a/chapter-persistence/src/main/scala/aia/persistence/sharded/ShardedShopper.scala
+++ b/chapter-persistence/src/main/scala/aia/persistence/sharded/ShardedShopper.scala
@@ -1,13 +1,10 @@
 package aia.persistence.sharded
 
 import scala.concurrent.duration._
-
 import akka.actor._
-
-import akka.contrib.pattern.ShardRegion
-import akka.contrib.pattern.ShardRegion.Passivate
-
 import aia.persistence._
+import akka.cluster.sharding.ShardRegion
+import akka.cluster.sharding.ShardRegion.Passivate
 
 object ShardedShopper {
   def props = Props(new ShardedShopper)
@@ -18,11 +15,11 @@ object ShardedShopper {
 
   val shardName: String = "shoppers"
 
-  val idExtractor: ShardRegion.IdExtractor = {
+  val extractEntityId: ShardRegion.ExtractEntityId = {
     case cmd: Shopper.Command => (cmd.shopperId.toString, cmd)
   }
 
-  val shardResolver: ShardRegion.ShardResolver = {
+  val extractShardId: ShardRegion.ExtractShardId = {
     case cmd: Shopper.Command => (cmd.shopperId % 12).toString
   }
 }

--- a/chapter-persistence/src/main/scala/aia/persistence/sharded/ShardedShoppers.scala
+++ b/chapter-persistence/src/main/scala/aia/persistence/sharded/ShardedShoppers.scala
@@ -1,9 +1,8 @@
 package aia.persistence.sharded
 
 import akka.actor._
-import akka.contrib.pattern.ClusterSharding
-
 import aia.persistence._
+import akka.cluster.sharding.{ClusterSharding, ClusterShardingSettings}
 
 object ShardedShoppers {
   def props= Props(new ShardedShoppers)
@@ -11,12 +10,21 @@ object ShardedShoppers {
 }
 
 class ShardedShoppers extends Actor {
+
   ClusterSharding(context.system).start(
-    typeName = ShardedShopper.shardName,
-    entryProps = Some(ShardedShopper.props),
-    idExtractor = ShardedShopper.idExtractor,
-    shardResolver = ShardedShopper.shardResolver
-  )
+    ShardedShopper.shardName,
+    ShardedShopper.props,
+    ClusterShardingSettings(context.system), // BUGBUG Captured all of below?
+    ShardedShopper.extractEntityId,
+    ShardedShopper.extractShardId
+                                       )
+
+//  ClusterSharding(context.system).start(  // BUGBUG goes with above!
+//    typeName = ShardedShopper.shardName,
+//    entryProps = Some(ShardedShopper.props),
+//    idExtractor = ShardedShopper.idExtractor,
+//    shardResolver = ShardedShopper.shardResolver
+//  )
 
   def shardedShopper = {
     ClusterSharding(context.system).shardRegion(ShardedShopper.shardName)


### PR DESCRIPTION
Updates to work with Akka 2.4.4 and Scala 2.11.7
  - akka-persistence no longer has experimental status
  - cluster-tools and cluster-sharding no longer part of akka-contrib
  - ClusterSharding API changed from Akka 2.3 to 2.4
  - ClusterSingletonManager and ClusterSingletonProxy APIs changed from Akka 2.3 to 2.4
  - idExtractor and shardResolver and their type names changed from Akka 2.3 to 2.4

LevelDB, journaling and snapshotting:
  - dependencies added for journaling support
  - application.conf sets up journal and snapshot store

Unit tests now run out of the box from SBT.  I haven't handled the deprecations for the changes from PersistentView to Persistence Query yet, because I haven't needed to, but may tweak those
in a future PR.
