### PR TITLE
Improve test readability for fault tolerance chapter tests

### DIFF
--- a/chapter-fault-tolerance/src/main/scala/aia/faulttolerance/LifeCycleHooks.scala
+++ b/chapter-fault-tolerance/src/main/scala/aia/faulttolerance/LifeCycleHooks.scala
@@ -1,42 +1,53 @@
 package aia.faulttolerance
 
+import aia.faulttolerance.LifeCycleHooks.{ForceRestart, ForceRestartException}
 import akka.actor._
 
+object LifeCycleHooks {
+
+  object SampleMessage
+
+  object ForceRestart
+
+  private class ForceRestartException extends IllegalArgumentException("force restart")
+
+}
+
 class LifeCycleHooks extends Actor with ActorLogging {
-  println("Constructor")
+  log.info("Constructor")
   //<start id="ch3-life-start"/>
   override def preStart(): Unit = {
-    println("preStart") //<co id="ch3-life-start-1" />
+    log.info("preStart") //<co id="ch3-life-start-1" />
   }
   //<end id="ch3-life-start"/>
 
   //<start id="ch3-life-stop"/>
   override def postStop(): Unit = {
-    println("postStop") //<co id="ch3-life-stop-1" />
+    log.info("postStop") //<co id="ch3-life-stop-1" />
   }
   //<end id="ch3-life-stop"/>
 
   //<start id="ch3-life-pre-restart"/>
   override def preRestart(reason: Throwable, //<co id="ch3-life-pre-restart-1a" />
                           message: Option[Any]): Unit = { //<co id="ch3-life-pre-restart-1b" />
-    println("preRestart")
+    log.info(s"preRestart. Reason: $reason when handling message: $message")
     super.preRestart(reason, message) //<co id="ch3-life-pre-restart-2" />
   }
   //<end id="ch3-life-pre-restart"/>
 
   //<start id="ch3-life-post-restart"/>
   override def postRestart(reason: Throwable): Unit = { //<co id="ch3-life-post-restart-1" />
-    println("postRestart")
+    log.info("postRestart")
     super.postRestart(reason) //<co id="ch3-life-post-restart-2" />
 
   }
   //<end id="ch3-life-post-restart"/>
 
   def receive = {
-    case "restart" =>
-      throw new IllegalStateException("force restart")
+    case ForceRestart =>
+      throw new ForceRestartException
     case msg: AnyRef =>
-      println("Receive")
+      log.info(s"Received: '$msg'. Sending back")
       sender() ! msg
   }
 }

--- a/chapter-fault-tolerance/src/test/scala/aia/faulttolerance/LifeCycleHooksTest.scala
+++ b/chapter-fault-tolerance/src/test/scala/aia/faulttolerance/LifeCycleHooksTest.scala
@@ -1,8 +1,9 @@
 package aia.faulttolerance
 
-import org.scalatest.{WordSpecLike, BeforeAndAfterAll}
-import akka.testkit.TestKit
+import aia.faulttolerance.LifeCycleHooks.{ForceRestart, SampleMessage}
 import akka.actor._
+import akka.testkit.TestKit
+import org.scalatest.{BeforeAndAfterAll, WordSpecLike}
 
 class LifeCycleHooksTest extends TestKit(ActorSystem("LifCycleTest")) with WordSpecLike with BeforeAndAfterAll {
 
@@ -15,11 +16,12 @@ class LifeCycleHooksTest extends TestKit(ActorSystem("LifCycleTest")) with WordS
       //<start id="ch3-life-test"/>
       val testActorRef = system.actorOf( //<co id="ch3-life-test-start" />
         Props[LifeCycleHooks], "LifeCycleHooks")
-      testActorRef ! "restart" //<co id="ch3-life-test-restart" />
-      testActorRef.tell("msg", testActor)
-      expectMsg("msg")
+      watch(testActorRef)
+      testActorRef ! ForceRestart //<co id="ch3-life-test-restart" />
+      testActorRef.tell(SampleMessage, testActor)
+      expectMsg(SampleMessage)
       system.stop(testActorRef) //<co id="ch3-life-test-stop" />
-      Thread.sleep(1000)
+      expectTerminated(testActorRef)
       //<end id="ch3-life-test"/>
 
     }


### PR DESCRIPTION
- Introduce LifeCycleHook object with messages and exception
- Move all println to logger calls
- Add info to logged event
- Remove Thread.sleep in favor of expectTerminated