### PR TITLE
Fix blank lines in config

### DIFF
--- a/chapter-persistence/build.sbt
+++ b/chapter-persistence/build.sbt
@@ -15,27 +15,20 @@ libraryDependencies ++= {
   val akkaVersion = "2.4.14"
   Seq(
     "com.typesafe.akka"         %%  "akka-actor"                          % akkaVersion,
-
     "com.typesafe.akka"         %%  "akka-persistence"                    % akkaVersion,
     "com.typesafe.akka"         %%  "akka-persistence-query-experimental" % akkaVersion,
     "org.iq80.leveldb"           %  "leveldb"                             % "0.7",
     "org.fusesource.leveldbjni"  %  "leveldbjni-all"                      % "1.8",
-
     "com.typesafe.akka"         %%  "akka-cluster"                        % akkaVersion,
     "com.typesafe.akka"         %%  "akka-cluster-tools"                  % akkaVersion,
     "com.typesafe.akka"         %%  "akka-cluster-sharding"               % akkaVersion,
-
     "com.typesafe.akka"         %% "akka-http-core"                       % "2.4.11", 
     "com.typesafe.akka"         %% "akka-http-experimental"               % "2.4.11", 
     "com.typesafe.akka"         %% "akka-http-spray-json-experimental"    % "2.4.11", 
-
     "com.typesafe.akka"         %%  "akka-testkit"                        % akkaVersion   % "test",
     "com.typesafe.akka"         %%  "akka-multi-node-testkit"             % akkaVersion   % "test",
-
     "commons-io"                %   "commons-io"                          % "2.4",
-
     "org.scalatest"             %%  "scalatest"                           % "3.0.0"       % "test",
-
     "com.typesafe.akka"         %%  "akka-slf4j"                          % akkaVersion,
     "ch.qos.logback"            %   "logback-classic"                     % "1.1.2"
   )

--- a/chapter-remoting/build.sbt
+++ b/chapter-remoting/build.sbt
@@ -10,10 +10,8 @@ libraryDependencies ++= {
   Seq(
     "com.typesafe.akka" %%  "akka-actor"              % akkaVersion,
     "com.typesafe.akka" %%  "akka-slf4j"              % akkaVersion,
-
     "com.typesafe.akka" %%  "akka-remote"             % akkaVersion,
     "com.typesafe.akka" %%  "akka-multi-node-testkit" % akkaVersion % "test",
-
     "com.typesafe.akka" %%  "akka-testkit"            % akkaVersion % "test",
     "org.scalatest"     %%  "scalatest"               % "3.0.0"     % "test",
     "com.typesafe.akka" %%  "akka-http-core"          % akkaHttpVersion,


### PR DESCRIPTION
Blank lines in chapter-remoting/build.sbt and in chapter-persistence/build.sbt break the build. After removing them build succeeds.

```
sergey$ sbt clean
[info] Loading project definition from /Users/sergey/Temp/akka-in-action/project
/Users/sergey/Temp/akka-in-action/chapter-remoting/build.sbt:12: error: illegal start of simple expression
    "com.typesafe.akka" %%  "akka-slf4j"              % akkaVersion,
                                                                    ^
[error] Error parsing expression.  Ensure that there are no blank lines within a setting.
Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? q

sergey$ vim chapter-remoting/build.sbt 
sergey$ sbt clean
[info] Loading project definition from /Users/sergey/Temp/akka-in-action/project
/Users/sergey/Temp/akka-in-action/chapter-persistence/build.sbt:17: error: illegal start of simple expression
    "com.typesafe.akka"         %%  "akka-actor"                          % akkaVersion,
                                                                                        ^
[error] Error parsing expression.  Ensure that there are no blank lines within a setting.
Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? q
sergey$ vim chapter-persistence/build.sbt 


sergey$ sbt clean
[info] Loading project definition from /Users/sergey/Temp/akka-in-action/project
[info] Set current project to all (in build file:/Users/sergey/Temp/akka-in-action/)
[success] Total time: 1 s, completed Feb 2, 2017 10:35:49 PM
```