### PR TITLE
Set sbt.version to 0.13.16

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16


### PR DESCRIPTION
This project requires several sbt plugins whose specified versions are
incompatible with 1.0.x . Beginners are affected by this because the
sbt website has 1.0.x as the default download.