### PR TITLE
[chapter-cluster][fixes #65] registerOnMemberUp callback

### DIFF
--- a/chapter-cluster/src/main/resources/seed.conf
+++ b/chapter-cluster/src/main/resources/seed.conf
@@ -30,7 +30,9 @@ akka {
     roles = ["seed"] #//<co id="seed_role"/>
 
     role {
-      seed.min-nr-of-members = 1 #//<co id="min_seed_members"/>
+      seed.min-nr-of-members = 1
+      master.min-nr-of-members = 1
+      worker.min-nr-of-members = 2
     }
   }
 }


### PR DESCRIPTION
Hi,
Added "min-nr-of-members" for master and worker in seed.conf file.

This fixes #65 issue of forming cluster too early - without having "worker.min-nr-of-members = 2" satisfied when running:
 one node using seed.conf config,
 one node using master.conf,
 two nodes using worker.conf.

After this fix callback function in "Cluster(system).registerOnMemberUp(callback)" will execute only when at least 2 worker nodes will be up.

It works because all nodes are running the same "role.<role-name>.min-nr-of-members" constraints (for all possible <roll-name>). In other words: there is now constraint for both master and worker role in the seed.conf file (only seed role "min-nr-of-member" constraint was not sufficient).
